### PR TITLE
fixing some new pandas deprecation warnings

### DIFF
--- a/scripts/7_analyses/giraf/giraf.py
+++ b/scripts/7_analyses/giraf/giraf.py
@@ -91,7 +91,7 @@ def parse_intercaat(filename, lut = None):
     # change qc to ic, for chain B
     interactions_df['ic_map_res_num'] = 0
     for p in range(0, len(interactions_df)):
-         interactions_df['ic_map_res_num'].iloc[p] = lut['consensus'].loc[lut[protein]+110 == int(interactions_df['ic_res_num'].iloc[p])]
+         interactions_df.loc[p, 'ic_map_res_num'] = lut['consensus'].loc[lut[protein]+110 == int(interactions_df['ic_res_num'].iloc[p])].values
          p = p + 1
         
     interactions_df['ic_map_res_num'] = interactions_df['ic_map_res_num'].astype(str)
@@ -220,8 +220,8 @@ analysis_dir = '/home/ra29435/Documents/Public_GitHub/Influenza_H5-Antibody_Pred
 # file1 = 'EPI242227__AVFluIgG01.pdb_intercaat.txt'
 # ab= 'AVFluIgG01' # set antibody of interest to match file1 above
 
-file1='EPI242227__H5.3.pdb_intercaat.txt'
-ab='H5.3'
+file1='EPI242227__FLD21.140.pdb_intercaat.txt'
+ab='FLD21'
 
 df1 = parse_intercaat(analysis_dir + file1, lut)
 graph1, idf = generate_graph(df1, variables=VARIABLES)

--- a/scripts/7_analyses/giraf/preprocess_align.py
+++ b/scripts/7_analyses/giraf/preprocess_align.py
@@ -37,22 +37,22 @@ def make_lut(filename):
     # The consensus sequence MUST be in row 0.
     p = 1;
     lut = pd.DataFrame(data=consensus_order, columns=['consensus'])
+    lut.loc[:, msa['protein'].iloc[1:]] = np.nan
     while p <= len(msa)-1:
     #while p <= 2:
         variant = msa['protein'].iloc[p]
-        lut[variant] = np.nan
-        print('Making LUT for ' + msa['protein'].iloc[p])
+        print('Making LUT for ' + msa.loc[p, 'protein'])
         count = 0;
         for m in range(0,len(msa['sequence'].iloc[p])):
             
             # Check if there is a point mutation
             if msa['sequence'].iloc[p][m].isalpha():
-                lut[variant].iloc[m] = count
+                lut.loc[m, variant] = count
                 count = count + 1;
             
             # check if it's same as consensus
             elif msa['sequence'].iloc[p][m] in '.' :
-               lut[variant].iloc[m] = count
+               lut.loc[m, variant] = count
                count = count + 1;
                 
             # check if there's a deletion        


### PR DESCRIPTION
For future resilience, this adjusts the way that pandas dataframes are being manipulated.

see: https://pandas.pydata.org/pandas-docs/stable/user_guide/copy_on_write.html#